### PR TITLE
iAPI Router: Fix how style and link elements are marked as `preload`

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/render.php
@@ -85,4 +85,9 @@ $wrapper_attributes = get_block_wrapper_attributes();
 	>
 		Client-side navigation
 	</div>
+
+	<!-- Text to check whether a page is being prefetched. -->
+	<div data-wp-interactive="test/router-styles" >
+		Prefetching: <span data-testid="prefetching" data-wp-text="state.prefetching"></span>
+	</div>
 </div>

--- a/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/router-styles-wrapper/view.js
@@ -6,6 +6,7 @@ import { store, getElement } from '@wordpress/interactivity';
 const { state } = store( 'test/router-styles', {
 	state: {
 		clientSideNavigation: false,
+		prefetching: false,
 	},
 	actions: {
 		*navigate( e ) {
@@ -17,11 +18,13 @@ const { state } = store( 'test/router-styles', {
 			state.clientSideNavigation = true;
 		},
 		*prefetch() {
+			state.prefetching = true;
 			const { ref } = getElement();
 			const { actions } = yield import(
 				'@wordpress/interactivity-router'
 			);
 			yield actions.prefetch( ref.href );
+			state.prefetching = false;
 		},
 	},
 } );

--- a/packages/interactivity-router/src/assets/styles.ts
+++ b/packages/interactivity-router/src/assets/styles.ts
@@ -158,10 +158,10 @@ const prepareStylePromise = (
 		return stylePromiseCache.get( element );
 	}
 
-	// When the `sheet` property is different from null, that means the
-	// element exists in the DOM and the style sheet has been loaded.
+	// When the element exists in the main document and its media attribute
+	// is not "preload", that means the element comes from the initial page.
 	// The `media` attribute doesn't need to be handled in this case.
-	if ( element.sheet ) {
+	if ( window.document.contains( element ) && element.media !== 'preload' ) {
 		const promise = Promise.resolve( element );
 		stylePromiseCache.set( element, promise );
 		return promise;

--- a/packages/interactivity-router/src/assets/styles.ts
+++ b/packages/interactivity-router/src/assets/styles.ts
@@ -75,8 +75,9 @@ export function updateStylesWithSCS(
 ) {
 	if ( X.length === 0 ) {
 		return Y.map( ( element ) => {
+			const promise = prepareStylePromise( element );
 			parent.appendChild( element );
-			return prepareStylePromise( element );
+			return promise;
 		} );
 	}
 

--- a/packages/interactivity-router/src/assets/test/styles.test.ts
+++ b/packages/interactivity-router/src/assets/test/styles.test.ts
@@ -113,13 +113,19 @@ describe( 'Router styles management', () => {
 			parent.append( ...X );
 
 			const promises = updateStylesWithSCS( X, [], parent );
+			const { childNodes } = parent;
 
 			// No new promises should be generated.
 			expect( promises.length ).toBe( 0 );
+
 			// The DOM should still only have the original X elements.
-			expect( parent.childNodes.length ).toBe( X.length );
-			expect( parent.childNodes[ 0 ] ).toBe( style1 );
-			expect( parent.childNodes[ 1 ] ).toBe( style2 );
+			expect( childNodes.length ).toBe( X.length );
+			expect( childNodes[ 0 ] ).toBe( style1 );
+			expect( childNodes[ 1 ] ).toBe( style2 );
+
+			// Verify the correct media attribute is set.
+			expect( childNodes[ 0 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 1 ] ).not.toHaveAttribute( 'media', 'preload' );
 		} );
 
 		it( 'should keep existing elements when they match in both X and Y', () => {
@@ -135,12 +141,18 @@ describe( 'Router styles management', () => {
 			parent.append( ...X );
 
 			const promises = updateStylesWithSCS( X, Y, parent );
+			const { childNodes } = parent;
 
 			expect( promises.length ).toBe( 2 );
-			expect( parent.childNodes.length ).toBe( 2 );
+			expect( childNodes.length ).toBe( 2 );
+
 			// Should maintain the original elements (not replace with clones).
-			expect( parent.childNodes[ 0 ] ).toBe( X[ 0 ] );
-			expect( parent.childNodes[ 1 ] ).toBe( X[ 1 ] );
+			expect( childNodes[ 0 ] ).toBe( X[ 0 ] );
+			expect( childNodes[ 1 ] ).toBe( X[ 1 ] );
+
+			// Verify the correct media attribute is set.
+			expect( childNodes[ 0 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 1 ] ).not.toHaveAttribute( 'media', 'preload' );
 		} );
 
 		it( 'should insert new elements from Y in correct positions relative to X', () => {
@@ -158,13 +170,20 @@ describe( 'Router styles management', () => {
 			parent.append( ...X );
 
 			const promises = updateStylesWithSCS( X, Y, parent );
+			const { childNodes } = parent;
 
 			expect( promises.length ).toBe( 4 );
-			expect( parent.childNodes.length ).toBe( 4 );
-			expect( parent.childNodes[ 0 ] ).toBe( X[ 0 ] );
-			expect( parent.childNodes[ 1 ] ).toBe( Y[ 1 ] );
-			expect( parent.childNodes[ 2 ] ).toBe( X[ 1 ] );
-			expect( parent.childNodes[ 3 ] ).toBe( Y[ 3 ] );
+			expect( childNodes.length ).toBe( 4 );
+			expect( childNodes[ 0 ] ).toBe( X[ 0 ] );
+			expect( childNodes[ 1 ] ).toBe( Y[ 1 ] );
+			expect( childNodes[ 2 ] ).toBe( X[ 1 ] );
+			expect( childNodes[ 3 ] ).toBe( Y[ 3 ] );
+
+			// Verify the correct media attribute is set.
+			expect( childNodes[ 0 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 1 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 2 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 3 ] ).toHaveAttribute( 'media', 'preload' );
 		} );
 
 		it( 'should handle Y having completely different elements than X', () => {
@@ -180,16 +199,23 @@ describe( 'Router styles management', () => {
 			parent.append( ...X );
 
 			const promises = updateStylesWithSCS( X, Y, parent );
+			const { childNodes } = parent;
 
 			expect( promises.length ).toBe( 2 );
 
 			// Check the specific order - based on the SCS algorithm.
 			// When X and Y are completely different, the SCS places.
 			// all elements from Y before X.
-			expect( parent.childNodes[ 0 ] ).toBe( Y[ 0 ] );
-			expect( parent.childNodes[ 1 ] ).toBe( Y[ 1 ] );
-			expect( parent.childNodes[ 2 ] ).toBe( X[ 0 ] );
-			expect( parent.childNodes[ 3 ] ).toBe( X[ 1 ] );
+			expect( childNodes[ 0 ] ).toBe( Y[ 0 ] );
+			expect( childNodes[ 1 ] ).toBe( Y[ 1 ] );
+			expect( childNodes[ 2 ] ).toBe( X[ 0 ] );
+			expect( childNodes[ 3 ] ).toBe( X[ 1 ] );
+
+			// Verify the correct media attribute is set.
+			expect( childNodes[ 0 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 1 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 2 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 3 ] ).not.toHaveAttribute( 'media', 'preload' );
 		} );
 
 		it( 'should consider normalized media attributes when comparing elements', () => {
@@ -205,10 +231,14 @@ describe( 'Router styles management', () => {
 			parent.append( ...X );
 
 			const promises = updateStylesWithSCS( X, Y, parent );
+			const { childNodes } = parent;
 
-			expect( parent.childNodes.length ).toBe( 1 );
+			expect( childNodes.length ).toBe( 1 );
 			expect( promises.length ).toBe( 1 );
-			expect( parent.childNodes[ 0 ] ).toBe( X[ 0 ] );
+			expect( childNodes[ 0 ] ).toBe( X[ 0 ] );
+
+			// Verify the media attribute has not changed.
+			expect( childNodes[ 0 ] ).toHaveAttribute( 'media', 'preload' );
 		} );
 
 		it( 'should treat style elements as already loaded', async () => {
@@ -271,17 +301,18 @@ describe( 'Router styles management', () => {
 			const Y = [ newStyle1, newStyle3, newStyle5, newStyle2, newStyle6 ];
 
 			const promises = updateStylesWithSCS( X, Y, parent );
+			const { childNodes } = parent;
 
 			expect( promises.length ).toBe( 5 );
 
 			// Verify the exact order.
-			expect( parent.childNodes[ 0 ] ).toBe( style1 );
-			expect( parent.childNodes[ 1 ] ).toBe( newStyle3 );
-			expect( parent.childNodes[ 2 ] ).toBe( newStyle5 );
-			expect( parent.childNodes[ 3 ] ).toBe( style2 );
-			expect( parent.childNodes[ 4 ] ).toBe( newStyle6 );
-			expect( parent.childNodes[ 5 ] ).toBe( style3 );
-			expect( parent.childNodes[ 6 ] ).toBe( style4 );
+			expect( childNodes[ 0 ] ).toBe( style1 );
+			expect( childNodes[ 1 ] ).toBe( newStyle3 );
+			expect( childNodes[ 2 ] ).toBe( newStyle5 );
+			expect( childNodes[ 3 ] ).toBe( style2 );
+			expect( childNodes[ 4 ] ).toBe( newStyle6 );
+			expect( childNodes[ 5 ] ).toBe( style3 );
+			expect( childNodes[ 6 ] ).toBe( style4 );
 
 			// Verify the promise values.
 			const values = await Promise.all( promises );
@@ -290,6 +321,15 @@ describe( 'Router styles management', () => {
 			expect( values[ 2 ] ).toBe( newStyle5 );
 			expect( values[ 3 ] ).toBe( style2 );
 			expect( values[ 4 ] ).toBe( newStyle6 );
+
+			// Verify the correct media attribute is set.
+			expect( childNodes[ 0 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 1 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 2 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 3 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 4 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 5 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 6 ] ).not.toHaveAttribute( 'media', 'preload' );
 		} );
 
 		it( 'should handle link elements with load events', async () => {
@@ -339,13 +379,14 @@ describe( 'Router styles management', () => {
 
 			// Run the update using X and Y.
 			const promises = updateStylesWithSCS( X, Y, parent );
+			const { childNodes } = parent;
 
 			// Expected DOM outcome (based on the SCS algorithm):.
 			// We expect that the existing link1 and link2 are reused, and the new link3 is inserted.
 			// The duplicate occurrences of link1 (via link1Clone and link1 itself in Y).
 			// should resolve to the original link1.
-			expect( parent.childNodes.length ).toBe( 7 );
-			expect( [ ...parent.childNodes ] ).toEqual( [
+			expect( childNodes.length ).toBe( 7 );
+			expect( [ ...childNodes ] ).toEqual( [
 				X[ 0 ],
 				Y[ 1 ],
 				X[ 1 ],
@@ -355,8 +396,8 @@ describe( 'Router styles management', () => {
 				X[ 4 ],
 			] );
 
-			( parent.childNodes as NodeListOf< StyleElement > ).forEach(
-				( element ) => element.dispatchEvent( new Event( 'load' ) )
+			( childNodes as NodeListOf< StyleElement > ).forEach( ( element ) =>
+				element.dispatchEvent( new Event( 'load' ) )
 			);
 
 			// Verify that the returned promises resolve to the appropriate elements.
@@ -371,6 +412,15 @@ describe( 'Router styles management', () => {
 				X[ 3 ],
 				Y[ 5 ],
 			] );
+
+			// Verify the correct media attribute is set.
+			expect( childNodes[ 0 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 1 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 2 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 3 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 4 ] ).not.toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 5 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 6 ] ).not.toHaveAttribute( 'media', 'preload' );
 		} );
 
 		it( 'should set media and data-original-media correctly on new elements', async () => {
@@ -496,8 +546,12 @@ describe( 'Router styles management', () => {
 			prepareStyles( doc, 'https://example.com/another-test-page' );
 
 			// Check that styles were extracted and added to the document.
-			expect( document.querySelector( '#test-style-1' ) ).toBeTruthy();
-			expect( document.querySelector( '#test-link-1' ) ).toBeTruthy();
+			const addedStyle1 = document.querySelector( '#test-style-1' );
+			const addedLink1 = document.querySelector( '#test-link-1' );
+			expect( addedStyle1 ).toBeTruthy();
+			expect( addedLink1 ).toBeTruthy();
+			expect( addedStyle1 ).toHaveAttribute( 'media', 'preload' );
+			expect( addedLink1 ).toHaveAttribute( 'media', 'preload' );
 		} );
 	} );
 

--- a/packages/interactivity-router/src/assets/test/styles.test.ts
+++ b/packages/interactivity-router/src/assets/test/styles.test.ts
@@ -82,14 +82,20 @@ describe( 'Router styles management', () => {
 				createStyleElement( 'style2' ),
 			];
 			const promises = updateStylesWithSCS( X, Y, parent );
+			const { childNodes } = parent;
 
 			expect( promises.length ).toBe( 3 );
-			expect( parent.childNodes.length ).toBe( 3 );
+			expect( childNodes.length ).toBe( 3 );
 
 			// Verify elements are in the correct order.
-			expect( parent.childNodes[ 0 ] ).toBe( Y[ 0 ] );
-			expect( parent.childNodes[ 1 ] ).toBe( Y[ 1 ] );
-			expect( parent.childNodes[ 2 ] ).toBe( Y[ 2 ] );
+			expect( childNodes[ 0 ] ).toBe( Y[ 0 ] );
+			expect( childNodes[ 1 ] ).toBe( Y[ 1 ] );
+			expect( childNodes[ 2 ] ).toBe( Y[ 2 ] );
+
+			// Verify the correct media attribute is set.
+			expect( childNodes[ 0 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 1 ] ).toHaveAttribute( 'media', 'preload' );
+			expect( childNodes[ 2 ] ).toHaveAttribute( 'media', 'preload' );
 		} );
 
 		it( 'should handle when both X and Y are empty', () => {

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -242,8 +242,11 @@ interface Store {
 		};
 	};
 	actions: {
-		navigate: ( href: string, options?: NavigateOptions ) => void;
-		prefetch: ( url: string, options?: PrefetchOptions ) => void;
+		navigate: (
+			href: string,
+			options?: NavigateOptions
+		) => Promise< void >;
+		prefetch: ( url: string, options?: PrefetchOptions ) => Promise< void >;
 	};
 }
 
@@ -377,8 +380,10 @@ export const { state, actions } = store< Store >( 'core/router', {
 		 * @param [options]       Options object.
 		 * @param [options.force] Force fetching the URL again.
 		 * @param [options.html]  HTML string to be used instead of fetching the requested URL.
+		 *
+		 * @return  Promise that resolves once the page has been fetched.
 		 */
-		prefetch( url: string, options: PrefetchOptions = {} ) {
+		*prefetch( url: string, options: PrefetchOptions = {} ) {
 			const { clientNavigationDisabled } = getConfig();
 			if ( clientNavigationDisabled ) {
 				return;
@@ -391,6 +396,8 @@ export const { state, actions } = store< Store >( 'core/router', {
 					fetchPage( pagePath, { html: options.html } )
 				);
 			}
+
+			yield pages.get( pagePath );
 		},
 	},
 } );

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -285,4 +285,29 @@ test.describe( 'Router styles', () => {
 		await expect( red ).toHaveCSS( 'color', COLOR_RED );
 		await expect( redBlock ).toBeVisible();
 	} );
+
+	test( 'should not apply preloaded styles in current page', async ( {
+		page,
+	} ) => {
+		const red = page.getByTestId( 'red-from-inline' );
+		const green = page.getByTestId( 'green-from-inline' );
+		const blue = page.getByTestId( 'blue-from-inline' );
+		const all = page.getByTestId( 'all-from-inline' );
+		const prefetching = page.getByTestId( 'prefetching' );
+
+		await expect( red ).toHaveCSS( 'color', COLOR_WRAPPER );
+		await expect( green ).toHaveCSS( 'color', COLOR_WRAPPER );
+		await expect( blue ).toHaveCSS( 'color', COLOR_WRAPPER );
+		await expect( all ).toHaveCSS( 'color', COLOR_WRAPPER );
+
+		await page.getByTestId( 'link red' ).hover();
+
+		// Wait until the prefetching has finished.
+		await expect( prefetching ).toHaveText( 'false' );
+
+		await expect( red ).toHaveCSS( 'color', COLOR_WRAPPER );
+		await expect( green ).toHaveCSS( 'color', COLOR_WRAPPER );
+		await expect( blue ).toHaveCSS( 'color', COLOR_WRAPPER );
+		await expect( all ).toHaveCSS( 'color', COLOR_WRAPPER );
+	} );
 } );

--- a/test/e2e/specs/interactivity/router-styles.spec.ts
+++ b/test/e2e/specs/interactivity/router-styles.spec.ts
@@ -301,6 +301,7 @@ test.describe( 'Router styles', () => {
 		await expect( all ).toHaveCSS( 'color', COLOR_WRAPPER );
 
 		await page.getByTestId( 'link red' ).hover();
+		await expect( prefetching ).toHaveText( 'true' );
 
 		// Wait until the prefetching has finished.
 		await expect( prefetching ).toHaveText( 'false' );


### PR DESCRIPTION
## What?

Fixes how the `prepareStylePromise` function marks style and link elements with media `preload`.
Also, fixes how `updateStylesWithSCS` handles an initial empty list.

## Why?

Two issues have been identified that were not being adequately tested:
1. The `prepareStylePromise` checked the existence of a `sheet` instance associated with style elements, assuming it would only exist for loaded elements in the main document. It turned out that `<style>` tags in other documents also have the `sheet` property populated.
2. When the initial list of styles is empty (i.e. a `<head>` element with no style tags, `updateStylesWithSCS` appended the new style tags before calling `prepareStylePromise`, making this function consider these new styles as if they were in the initial page.

## How?

1. The `prepareStylePromise` function now detects style elements from the main document by checking if the element is contained there and doesn't have a media `preload`.
2. The `updateStylesWithSCS` function now ensures `prepareStylePromise` is called before appending the new elements to the DOM.

## Testing Instructions

Added unit tests and e2e tests.
