### PR TITLE
iAPI Router: Separate full-page logic from the router bundle

### DIFF
--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -7,12 +7,17 @@
  * Enqueue the interactivity router script.
  */
 function _gutenberg_enqueue_interactivity_router() {
-	// Set the navigation mode to full page client-side navigation.
-	wp_interactivity_config( 'core/router', array( 'clientNavigationMode' => 'fullPage' ) );
 	wp_enqueue_script_module( '@wordpress/interactivity-router/full-page' );
 }
-
 add_action( 'wp_enqueue_scripts', '_gutenberg_enqueue_interactivity_router' );
+
+/**
+ * Sets the navigation mode to full page client-side navigation.
+ */
+function _gutenberg_interactivity_router_set_client_navigation_mode() {
+	wp_interactivity_config( 'core/router', array( 'clientNavigationMode' => 'fullPage' ) );
+}
+add_action( 'init', '_gutenberg_interactivity_router_set_client_navigation_mode', 9 );
 
 /**
  * Set enhancedPagination attribute for query loop when the experiment is enabled.

--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -9,7 +9,7 @@
 function _gutenberg_enqueue_interactivity_router() {
 	// Set the navigation mode to full page client-side navigation.
 	wp_interactivity_config( 'core/router', array( 'navigationMode' => 'fullPage' ) );
-	wp_enqueue_script_module( '@wordpress/interactivity-router' );
+	wp_enqueue_script_module( '@wordpress/interactivity-router/full-page' );
 }
 
 add_action( 'wp_enqueue_scripts', '_gutenberg_enqueue_interactivity_router' );

--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -33,69 +33,41 @@ function _gutenberg_add_enhanced_pagination_to_query_block( $parsed_block ) {
 add_filter( 'render_block_data', '_gutenberg_add_enhanced_pagination_to_query_block' );
 
 /**
- * Adds client-side navigation directives to BODY tag.
+ * Adds client-side navigation directives to BODY tag in the passed output
+ * buffer.
  *
- * Note: This should probably be done per site, not by default when this option is enabled.
+ * Note: This should probably be done per site, not by default when this option
+ * is enabled.
  *
- * @param string $response_body The response body.
+ * @param string $buffer Passed output buffer.
  *
- * @return string The rendered template with modified BODY attributes.
+ * @return string The same HTML with modified BODY attributes.
  */
-function _gutenberg_add_client_side_navigation_directives( $response_body ) {
-	$is_html_content_type = false;
-	foreach ( headers_list() as $header ) {
-		$header_parts = preg_split( '/\s*[:;]\s*/', strtolower( $header ) );
-		if ( count( $header_parts ) >= 2 && 'content-type' === $header_parts[0] ) {
-			$is_html_content_type = in_array( $header_parts[1], array( 'text/html', 'application/xhtml+xml' ), true );
-		}
-	}
-	if ( ! $is_html_content_type ) {
-		return $response_body;
-	}
-
-	$p = new WP_HTML_Tag_Processor( $response_body );
+function _gutenberg_add_client_side_navigation_directives( $buffer ) {
+	$p = new WP_HTML_Tag_Processor( $buffer );
 	if ( $p->next_tag( array( 'tag_name' => 'BODY' ) ) ) {
-		$p->set_attribute( 'data-wp-interactive', 'core/experimental' );
-		$p->set_attribute( 'data-wp-context', '{}' );
-		$response_body = $p->get_updated_html();
+		$p->set_attribute( 'data-wp-interactive', true );
+		$p->set_attribute( 'data-wp-router-region', 'body' );
+		return $p->get_updated_html();
+	} else {
+		return $buffer;
 	}
-	return $response_body;
 }
-
-// TODO: Explore moving this to the server directive processing.
-add_filter( 'gutenberg_template_output_buffer', '_gutenberg_add_client_side_navigation_directives' );
 
 /**
- * Starts output buffering at the end of the 'template_include' filter.
- *
- * This is to implement #43258 in core.
- *
- * This is a hack which would eventually be replaced with something like this in wp-includes/template-loader.php:
- *
- *          $template = apply_filters( 'template_include', $template );
- *     +    ob_start( 'wp_template_output_buffer_callback' );
- *          if ( $template ) {
- *              include $template;
- *          } elseif ( current_user_can( 'switch_themes' ) ) {
- *
- * @link https://core.trac.wordpress.org/ticket/43258
- *
- * @param string $passthrough Value for the template_include filter which is passed through.
- *
- * @return string Unmodified value of $passthrough.
+ * Starts output buffering at the end of the 'wp_head' action, adding the
+ * required directives for client-side navigation to the BODY tags when the
+ * buffer is flushed.
  */
-function _gutenberg_buffer_template_output( string $passthrough ): string {
-	ob_start(
-		static function ( string $output ): string {
-			/**
-			 * Filters the template output buffer prior to sending to the client.
-			 *
-			 * @param string $output Output buffer.
-			 * @return string Filtered output buffer.
-			 */
-			return (string) apply_filters( 'gutenberg_template_output_buffer', $output );
-		}
-	);
-	return $passthrough;
+function _gutenberg_full_page_client_navigation_buffer_start() {
+	ob_start( '_gutenberg_add_client_side_navigation_directives' );
 }
-add_filter( 'template_include', '_gutenberg_buffer_template_output', PHP_INT_MAX );
+add_action( 'wp_head', '_gutenberg_full_page_client_navigation_buffer_start' );
+
+/**
+ * Flushes the output buffer at the end of the 'wp_footer' action.
+ */
+function _gutenberg_full_page_client_navigation_buffer_end() {
+	ob_end_flush();
+}
+add_action( 'wp_footer', '_gutenberg_full_page_client_navigation_buffer_end' );

--- a/lib/experimental/full-page-client-side-navigation.php
+++ b/lib/experimental/full-page-client-side-navigation.php
@@ -8,7 +8,7 @@
  */
 function _gutenberg_enqueue_interactivity_router() {
 	// Set the navigation mode to full page client-side navigation.
-	wp_interactivity_config( 'core/router', array( 'navigationMode' => 'fullPage' ) );
+	wp_interactivity_config( 'core/router', array( 'clientNavigationMode' => 'fullPage' ) );
 	wp_enqueue_script_module( '@wordpress/interactivity-router/full-page' );
 }
 

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -26,6 +26,7 @@
 	"module": "build-module/index.js",
 	"exports": {
 		".": "./build-module/index.js",
+		"./package.json": "./package.json",
 		"./full-page": "./build-module/full-page.js"
 	},
 	"react-native": "src/index",

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -24,6 +24,10 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"exports": {
+		".": "./build-module/index.js",
+		"./full-page": "./build-module/full-page.js"
+	},
 	"react-native": "src/index",
 	"wpScriptModuleExports": {
 		".": "./build-module/index.js",

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -24,11 +24,6 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"exports": {
-		".": "./build-module/index.js",
-		"./package.json": "./package.json",
-		"./full-page": "./build-module/full-page.js"
-	},
 	"react-native": "src/index",
 	"wpScriptModuleExports": {
 		".": "./build-module/index.js",

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -25,7 +25,10 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"wpScriptModuleExports": "./build-module/index.js",
+	"wpScriptModuleExports": {
+		".": "./build-module/index.js",
+		"./full-page": "./build-module/full-page.js"
+	},
 	"types": "build-types",
 	"dependencies": {
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/interactivity-router/src/full-page.ts
+++ b/packages/interactivity-router/src/full-page.ts
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { getConfig } from '@wordpress/interactivity';
+
+// Check if the navigation mode is full page or region based.
+const navigationMode: 'regionBased' | 'fullPage' =
+	getConfig( 'core/router' ).navigationMode ?? 'regionBased';
+
+// Check if the link is valid for client-side navigation.
+const isValidLink = ( ref: HTMLAnchorElement ) =>
+	ref &&
+	ref instanceof window.HTMLAnchorElement &&
+	ref.href &&
+	( ! ref.target || ref.target === '_self' ) &&
+	ref.origin === window.location.origin &&
+	! ref.pathname.startsWith( '/wp-admin' ) &&
+	! ref.pathname.startsWith( '/wp-login.php' ) &&
+	! ref.getAttribute( 'href' ).startsWith( '#' ) &&
+	! new URL( ref.href ).searchParams.has( '_wpnonce' );
+
+// Check if the event is valid for client-side navigation.
+const isValidEvent = ( event: MouseEvent ) =>
+	event &&
+	event.button === 0 && // Left clicks only.
+	! event.metaKey && // Open in new tab (Mac).
+	! event.ctrlKey && // Open in new tab (Windows).
+	! event.altKey && // Download.
+	! event.shiftKey &&
+	! event.defaultPrevented;
+
+// Add click and prefetch to all links.
+if ( navigationMode === 'fullPage' ) {
+	// Navigate on click.
+	document.addEventListener(
+		'click',
+		async ( event ) => {
+			const ref = ( event.target as Element ).closest( 'a' );
+			if ( isValidLink( ref ) && isValidEvent( event ) ) {
+				event.preventDefault();
+				const { actions } = await import(
+					'@wordpress/interactivity-router'
+				);
+				actions.navigate( ref.href );
+			}
+		},
+		true
+	);
+	// Prefetch on hover.
+	document.addEventListener(
+		'mouseenter',
+		async ( event ) => {
+			if ( ( event.target as Element )?.nodeName === 'A' ) {
+				const ref = ( event.target as Element ).closest( 'a' );
+				if ( isValidLink( ref ) && isValidEvent( event ) ) {
+					const { actions } = await import(
+						'@wordpress/interactivity-router'
+					);
+					actions.prefetch( ref.href );
+				}
+			}
+		},
+		true
+	);
+}

--- a/packages/interactivity-router/src/full-page.ts
+++ b/packages/interactivity-router/src/full-page.ts
@@ -4,8 +4,8 @@
 import { getConfig } from '@wordpress/interactivity';
 
 // Check if the navigation mode is full page or region based.
-const navigationMode: 'regionBased' | 'fullPage' =
-	getConfig( 'core/router' ).navigationMode ?? 'regionBased';
+const clientNavigationMode: 'regionBased' | 'fullPage' =
+	getConfig( 'core/router' ).clientNavigationMode ?? 'regionBased';
 
 // Check if the link is valid for client-side navigation.
 const isValidLink = ( ref: HTMLAnchorElement ) =>
@@ -30,7 +30,7 @@ const isValidEvent = ( event: MouseEvent ) =>
 	! event.defaultPrevented;
 
 // Add click and prefetch to all links.
-if ( navigationMode === 'fullPage' ) {
+if ( clientNavigationMode === 'fullPage' ) {
 	// Navigate on click.
 	document.addEventListener(
 		'click',

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -29,6 +29,7 @@ const {
 
 const regionAttr = `data-${ directivePrefix }-router-region`;
 const interactiveAttr = `data-${ directivePrefix }-interactive`;
+const regionsSelector = `[${ interactiveAttr }][${ regionAttr }]:not([${ interactiveAttr }] [${ interactiveAttr }])`;
 
 export interface NavigateOptions {
 	force?: boolean;
@@ -59,10 +60,6 @@ interface Page {
 }
 
 type RegionsToVdom = ( dom: Document, params?: VdomParams ) => Promise< Page >;
-
-// Check if the navigation mode is full page or region based.
-const navigationMode: 'regionBased' | 'fullPage' =
-	getConfig( 'core/router' ).navigationMode ?? 'regionBased';
 
 // The cache of visited and prefetched pages, stylesheets and scripts.
 const pages = new Map< string, Promise< Page | false > >();
@@ -96,23 +93,13 @@ const fetchPage = async ( url: string, { html }: { html: string } ) => {
 const regionsToVdom: RegionsToVdom = async ( dom, { vdom, url } = {} ) => {
 	const regions = { body: undefined };
 
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		if ( navigationMode === 'fullPage' ) {
-			regions.body = vdom
-				? vdom.get( document.body )
-				: toVdom( dom.body );
-		}
-	}
-	if ( navigationMode === 'regionBased' ) {
-		dom.querySelectorAll(
-			`[${ interactiveAttr }][${ regionAttr }]:not([${ interactiveAttr }] [${ interactiveAttr }])`
-		).forEach( ( region ) => {
-			const id = region.getAttribute( regionAttr );
-			regions[ id ] = vdom?.has( region )
-				? vdom.get( region )
-				: toVdom( region );
-		} );
-	}
+	dom.querySelectorAll( regionsSelector ).forEach( ( region ) => {
+		const id = region.getAttribute( regionAttr );
+		regions[ id ] = vdom?.has( region )
+			? vdom.get( region )
+			: toVdom( region );
+	} );
+
 	const title = dom.querySelector( 'title' )?.innerText;
 	const initialData = parseServerData( dom );
 
@@ -130,30 +117,15 @@ const renderRegions = ( page: Page ) => {
 	applyStyles( page.styles );
 	importScriptModules( page.scriptModules );
 
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		if ( navigationMode === 'fullPage' ) {
-			// Update HTML.
-			const fragment = getRegionRootFragment( document.body );
-			batch( () => {
-				populateServerData( page.initialData );
-				render( page.regions.body, fragment );
-			} );
-		}
-	}
-	if ( navigationMode === 'regionBased' ) {
-		batch( () => {
-			populateServerData( page.initialData );
-			document
-				.querySelectorAll(
-					`[${ interactiveAttr }][${ regionAttr }]:not([${ interactiveAttr }] [${ interactiveAttr }])`
-				)
-				.forEach( ( region ) => {
-					const id = region.getAttribute( regionAttr );
-					const fragment = getRegionRootFragment( region );
-					render( page.regions[ id ], fragment );
-				} );
+	batch( () => {
+		populateServerData( page.initialData );
+		document.querySelectorAll( regionsSelector ).forEach( ( region ) => {
+			const id = region.getAttribute( regionAttr );
+			const fragment = getRegionRootFragment( region );
+			render( page.regions[ id ], fragment );
 		} );
-	}
+	} );
+
 	if ( page.title ) {
 		document.title = page.title;
 	}
@@ -201,28 +173,6 @@ pages.set(
 		} )
 	)
 );
-
-// Check if the link is valid for client-side navigation.
-const isValidLink = ( ref: HTMLAnchorElement ) =>
-	ref &&
-	ref instanceof window.HTMLAnchorElement &&
-	ref.href &&
-	( ! ref.target || ref.target === '_self' ) &&
-	ref.origin === window.location.origin &&
-	! ref.pathname.startsWith( '/wp-admin' ) &&
-	! ref.pathname.startsWith( '/wp-login.php' ) &&
-	! ref.getAttribute( 'href' ).startsWith( '#' ) &&
-	! new URL( ref.href ).searchParams.has( '_wpnonce' );
-
-// Check if the event is valid for client-side navigation.
-const isValidEvent = ( event: MouseEvent ) =>
-	event &&
-	event.button === 0 && // Left clicks only.
-	! event.metaKey && // Open in new tab (Mac).
-	! event.ctrlKey && // Open in new tab (Windows).
-	! event.altKey && // Download.
-	! event.shiftKey &&
-	! event.defaultPrevented;
 
 // Variable to store the current navigation.
 let navigatingTo = '';
@@ -444,35 +394,4 @@ function a11ySpeak( messageKey: keyof typeof navigationTexts ) {
 		// Ignore failures to load the a11y module.
 		() => {}
 	);
-}
-
-// Add click and prefetch to all links.
-if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-	if ( navigationMode === 'fullPage' ) {
-		// Navigate on click.
-		document.addEventListener(
-			'click',
-			function ( event ) {
-				const ref = ( event.target as Element ).closest( 'a' );
-				if ( isValidLink( ref ) && isValidEvent( event ) ) {
-					event.preventDefault();
-					actions.navigate( ref.href );
-				}
-			},
-			true
-		);
-		// Prefetch on hover.
-		document.addEventListener(
-			'mouseenter',
-			function ( event ) {
-				if ( ( event.target as Element )?.nodeName === 'A' ) {
-					const ref = ( event.target as Element ).closest( 'a' );
-					if ( isValidLink( ref ) && isValidEvent( event ) ) {
-						actions.prefetch( ref.href );
-					}
-				}
-			},
-			true
-		);
-	}
 }

--- a/packages/interactivity-router/tsconfig.full-page.json
+++ b/packages/interactivity-router/tsconfig.full-page.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"allowJs": false,
+		"checkJs": false,
+		"strict": false
+	},
+	"references": [ { "path": "tsconfig.main.json" } ],
+	"files": [ "src/full-page.ts" ],
+	"include": [],
+}

--- a/packages/interactivity-router/tsconfig.json
+++ b/packages/interactivity-router/tsconfig.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"compilerOptions": {
+		"composite": true
+	},
 	"references": [
 		{ "path": "../a11y" },
 		{ "path": "../interactivity" },

--- a/packages/interactivity-router/tsconfig.json
+++ b/packages/interactivity-router/tsconfig.json
@@ -11,3 +11,4 @@
 		{ "path": "tsconfig.full-page.json" }
 	]
 }
+ 

--- a/packages/interactivity-router/tsconfig.json
+++ b/packages/interactivity-router/tsconfig.json
@@ -1,9 +1,9 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"checkJs": false,
-		"strict": false
-	},
-	"references": [ { "path": "../a11y" }, { "path": "../interactivity" } ]
+	"references": [
+		{ "path": "../a11y" },
+		{ "path": "../interactivity" },
+		{ "path": "tsconfig.main.json" },
+		{ "path": "tsconfig.full-page.json" }
+	]
 }

--- a/packages/interactivity-router/tsconfig.json
+++ b/packages/interactivity-router/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"composite": true
 	},
+	"files": [],
 	"references": [
 		{ "path": "../a11y" },
 		{ "path": "../interactivity" },

--- a/packages/interactivity-router/tsconfig.main.json
+++ b/packages/interactivity-router/tsconfig.main.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"allowJs": false,
+		"checkJs": false,
+		"strict": false
+	},
+	"references": [ { "path": "../a11y" }, { "path": "../interactivity" } ],
+	"exclude": [
+		"**/*.android.js",
+		"**/*.ios.js",
+		"**/*.native.js",
+		"**/benchmark",
+		"build-*/**",
+		"build/**",
+		"**/test/**",
+		"**/react-native-*/**",
+		"src/full-page.ts"
+	]
+}


### PR DESCRIPTION
## What?

- [x] Remove all fullPage runtime code except the event delegation
- [x] Remove enqueue and import dynamically in event
- [x] Add `data-wp-router-region` to the body using `wp_head` and `wp_footer` approach
- [x] Rename `navigationMode` to `clientNavigationMode`
- [x] Move the config initialization to `init` with priority `9`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

