### PR TITLE
iAPI Router: Prevent navigation on links with `on--click` directives

### DIFF
--- a/packages/interactivity-router/src/full-page.ts
+++ b/packages/interactivity-router/src/full-page.ts
@@ -29,6 +29,30 @@ const isValidEvent = ( event: MouseEvent ) =>
 	! event.shiftKey &&
 	! event.defaultPrevented;
 
+/**
+ * Builds a callback function to test if a given attribute name corresponds to a
+ * `data-wp-on` or a `data-wp-on-async` directive for the given event type.
+ *
+ * @param event Event type.
+ * @return Callback function.
+ */
+const isWpOn = ( event: string ) => ( attrName: string ) =>
+	RegExp( `^data-wp-on(?:-async)?--${ event }(?:--([a-z0-9_-]+))?$` ).test(
+		attrName
+	);
+
+/**
+ * Determines whether the passed anchor element contains a `data-wp-on` or a
+ * `data-wp-on-async` directive for the given event type, returning `true` when
+ * it doesn't.
+ *
+ * @param event Event type to check.
+ * @param ref   An HTMLAnchorElement instance.
+ * @return Whether the pased element contains such a directive.
+ */
+const isLinkWithoutWpOn = ( event: string, ref: HTMLAnchorElement ) =>
+	! ref.getAttributeNames().some( isWpOn( event ) );
+
 // Add click and prefetch to all links.
 if ( clientNavigationMode === 'experimentalFullPage' ) {
 	// Navigate on click.
@@ -36,7 +60,11 @@ if ( clientNavigationMode === 'experimentalFullPage' ) {
 		'click',
 		async ( event ) => {
 			const ref = ( event.target as Element ).closest( 'a' );
-			if ( isValidLink( ref ) && isValidEvent( event ) ) {
+			if (
+				isValidLink( ref ) &&
+				isValidEvent( event ) &&
+				isLinkWithoutWpOn( 'click', ref )
+			) {
 				event.preventDefault();
 				const { actions } = await import(
 					'@wordpress/interactivity-router'
@@ -52,7 +80,11 @@ if ( clientNavigationMode === 'experimentalFullPage' ) {
 		async ( event ) => {
 			if ( ( event.target as Element )?.nodeName === 'A' ) {
 				const ref = ( event.target as Element ).closest( 'a' );
-				if ( isValidLink( ref ) && isValidEvent( event ) ) {
+				if (
+					isValidLink( ref ) &&
+					isValidEvent( event ) &&
+					isLinkWithoutWpOn( 'mouseenter', ref )
+				) {
 					const { actions } = await import(
 						'@wordpress/interactivity-router'
 					);


### PR DESCRIPTION
## What?

The Interactivity Router uses event delegation to capture `click` and `mouseenter` events from all links to call `actions.navigate` and `actions.prefetch` respectively.

This PR prevents doing so for link elements that already have directives for that purpose, e.g., links on a Pagination block inside a Query Loop with "Reload full page" disabled.


## Why?

To prevent unnecessary or duplicated navigation by giving more precedence to block-specific actions.

## How?

It checks the `event.target` elements for `data-wp-on--click` or `data-wp-on--mouseenter` directives (also for `data-wp-on-async` with the same events). If they are found, the router actions are not called. Directives with a unique ID are also considered (e.g., `data-wp-on--click--navigation`).

This is a heuristic we can iterate on later, as these directives could be unrelated to router actions (e.g., CSS animations or analytics callbacks).


